### PR TITLE
Add support for Azure OpenAI, as well as OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@ First, install dependencies
 Next, setup appropriate values in your `.env.local` file:
 
 ```
-# From OpenAI
+# Credentials if you want to use OpenAI as your LLM
 OPENAI_API_KEY=
+
+# Credentials if you want to use Azure OpenAI as your LLM
+AZURE_API_KEY=
+AZURE_MODEL_BASE_URL=https://copilot-chat-pool1-ide-westus.openai.azure.com/openai/v1/engines/copilot-gpt-4
 
 # From Supabase (only necessary if you are creating embeddings)
 NEXT_PUBLIC_SUPABASE_URL=

--- a/app/components/SettingsForm.tsx
+++ b/app/components/SettingsForm.tsx
@@ -13,10 +13,11 @@ import {
 } from "@primer/react";
 import type { ChatCompletionCreateParams } from "openai/resources/chat";
 import { availableFunctions, FunctionName } from "../api/chat/functions";
-import { type Model, type SettingsProps } from "../types";
+import { Provider, type Model, type SettingsProps } from "../types";
 import { indexedRepositories } from "../repositories";
 import { FUNCTION_CALLING_MODELS } from "../models";
 import { Visibility } from "./TitleBar";
+import { presentProvider } from "../utils/provider";
 
 type Props = {
   initialValues: SettingsProps;
@@ -90,17 +91,20 @@ export default function SettingsForm({
       ).trim();
       const tools = data.getAll("tools[]") as string[];
       const model = data.get("model") as Model;
+      const provider = data.get("provider") as Provider;
       const parallelize = data.get("fcStrategy") === "parallel";
       onSubmit({
         customInstructions,
         tools,
         model,
         parallelize,
+        provider,
       });
       //onDismiss();
     },
     [onSubmit],
   );
+
 
   return (
     <Box
@@ -139,19 +143,35 @@ export default function SettingsForm({
             <Box sx={{ flexGrow: 1 }}>Settings</Box>
           </Box>
           <FormControl>
-            <FormControl.Label>Model</FormControl.Label>
-            <Select name="model" sx={{ width: "100%" }}>
-              {FUNCTION_CALLING_MODELS.map((model) => (
+            <FormControl.Label>Provider</FormControl.Label>
+            <Select name="provider" sx={{ width: "100%" }}>
+              {Object.values(Provider).map((provider) => (
                 <Select.Option
-                  selected={model === initialValues.model}
-                  key={model}
-                  value={model}
+                  selected={provider == initialValues.provider}
+                  key={provider}
+                  value={provider}
                 >
-                  {model}
+                  {presentProvider(provider)}
                 </Select.Option>
               ))}
             </Select>
           </FormControl>
+          <Box pt={3}>
+            <FormControl>
+              <FormControl.Label>Model (OpenAI only)</FormControl.Label>
+              <Select name="model" sx={{ width: "100%" }}>
+                {FUNCTION_CALLING_MODELS.map((model) => (
+                  <Select.Option
+                    selected={model === initialValues.model}
+                    key={model}
+                    value={model}
+                  >
+                    {model}
+                  </Select.Option>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
           <Box pt={3}>
             <FormControl id="customInstructions">
               <FormControl.Label>Custom instructions</FormControl.Label>
@@ -167,7 +187,7 @@ export default function SettingsForm({
           </Box>
           <Box pt={3}>
             <RadioGroup name="fcStrategy">
-              <RadioGroup.Label>Function calling strategy</RadioGroup.Label>
+              <RadioGroup.Label>Function calling strategy (OpenAI only)</RadioGroup.Label>
               <CheckboxGroup.Caption>
                 Select whether a serial or parallel function calling strategy is
                 used. Parallel is not always better...or faster.

--- a/app/components/TitleBar.tsx
+++ b/app/components/TitleBar.tsx
@@ -5,7 +5,9 @@ import {
   GearIcon,
 } from "@primer/octicons-react";
 import { Button, IconButton, Box } from "@primer/react";
-import { SettingsProps } from "../types";
+import { Provider, SettingsProps } from "../types";
+import { presentProvider } from "../utils/provider";
+import pluralize from "../utils/pluralize";
 export type Visibility = "visible" | "hidden";
 type Props = {
   settingsVisibility: Visibility;
@@ -69,9 +71,9 @@ export default function TitleBar({
           flex: 1,
         }}
       >
-        Chatting with {currentSettings.model} using{" "}
+        Chatting with {presentProvider(currentSettings.provider)} {currentSettings.provider === Provider.OPENAI && `(${currentSettings.model})`} using{" "}
         {currentSettings.tools.length}{" "}
-        {currentSettings.parallelize ? "tools" : "functions"}.
+        {pluralize(currentSettings.parallelize ? "tool" : "function", currentSettings.tools.length)}.
       </Box>
       <Button onClick={onClear} leadingVisual={SyncIcon}>
         Clear

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import SettingsForm from "./components/SettingsForm";
 import { FUNCTION_CALLING_MODELS } from "./models";
 import { availableFunctions, FunctionName } from "./api/chat/functions";
 import useLocalStorage from "./hooks/useLocalStorage";
-import { SettingsProps, FunctionData } from "./types";
+import { SettingsProps, FunctionData, Provider } from "./types";
 import MessageInput from "./components/MessageInput";
 import Intro from "./components/Intro";
 import TitleBar, { Visibility } from "./components/TitleBar";
@@ -43,6 +43,7 @@ export default function Chat() {
     tools: tools,
     model: FUNCTION_CALLING_MODELS[0],
     parallelize: true,
+    provider: Provider.OPENAI
   });
 
   async function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {

--- a/app/types.ts
+++ b/app/types.ts
@@ -22,9 +22,15 @@ export type MessageData = {
   messages: ChatCompletionMessageParam[];
 };
 
+export enum Provider {
+  OPENAI = 'openai',
+  AZURE = 'azure',
+}
+
 export type SettingsProps = {
   customInstructions: string;
   tools: string[];
   model: Model;
+  provider: Provider;
   parallelize: boolean;
 };

--- a/app/utils/pluralize.ts
+++ b/app/utils/pluralize.ts
@@ -1,0 +1,5 @@
+const pluralize = (word: string, count: number): string => {
+  return count === 1 ? word : word + 's';
+}
+
+export default pluralize;

--- a/app/utils/provider.ts
+++ b/app/utils/provider.ts
@@ -1,0 +1,10 @@
+import { Provider } from "../types";
+
+export const presentProvider = (provider: Provider): string => {
+  switch (provider) {
+    case Provider.OPENAI:
+      return "OpenAI";
+    case Provider.AZURE:
+      return "Azure OpenAI";
+  }
+}


### PR DESCRIPTION
This adds support for using Azure OpenAI as the backing LLM, as well as the OpenAI API.

Your Azure credentials must be configured in `.env.local`, and then you can switch between LLM providers from the settings.

Only serial function-calling is supported in our Azure OpenAI setup at this time, and the model is static rather than configurable.