### PR TITLE
When the "Clear" button is pressed, clear the debug view as well as the message view

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,7 +35,7 @@ export default function Chat() {
     append,
     setMessages,
     stop,
-  } = useChat({ id: chatIndex });
+  } = useChat({ id: chatIndex.toString() });
 
   const debugData = data as unknown as FunctionData[];
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,6 +23,7 @@ export default function Chat() {
   const [file, setFile] = useState<File | null>(null);
   const [base64File, setBase64File] = useState<string | null>(null);
   const [fileInputKey, setFileInputKey] = useState<string>("a");
+  const [chatIndex, setChatIndex] = useState<number>(0);
 
   const {
     data,
@@ -34,7 +35,7 @@ export default function Chat() {
     append,
     setMessages,
     stop,
-  } = useChat();
+  } = useChat({ id: chatIndex });
 
   const debugData = data as unknown as FunctionData[];
 
@@ -112,6 +113,7 @@ export default function Chat() {
               onClear={() => {
                 stop();
                 setMessages([]);
+                setChatIndex(chatIndex + 1);
               }}
             />
 


### PR DESCRIPTION
At the moment, the "Clear" button in the top-right hand of the screen clears the "messages" view but not the "debug" view. This fixes that.

`ai` doesn't provide a clear way to clear the `data` variable which powers the "debug" view, so this takes an alternative approach: start a new "chat" by incrementing the chat's ID.